### PR TITLE
ログイン画面と、ユーザー情報登録画面では、ヘッダーのタブを表示しないようにした

### DIFF
--- a/src/app/_components/Layout/Header/Header.tsx
+++ b/src/app/_components/Layout/Header/Header.tsx
@@ -12,11 +12,15 @@ import { NavLink } from './NavLink'
 import { useState } from 'react'
 import Link from 'next/link'
 import { signOut, useSession } from 'next-auth/react'
+import { usePathname } from 'next/navigation'
 
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   const { data: session } = useSession()
+  const pathName = usePathname()
+
+  const isLoginPath = pathName === '/login' || pathName === '/login/enter'
 
   const handleLinkClick = () => {
     setIsMenuOpen(false)
@@ -51,37 +55,47 @@ export const Header = () => {
               ログアウト
             </Button>
           ) : (
-            <Link href="/login">
-              <Button color="primary">ログイン</Button>
-            </Link>
+            <>
+              {isLoginPath ? null : (
+                <Link href="/login">
+                  <Button color="primary">ログイン</Button>
+                </Link>
+              )}
+            </>
           )}
-          <NavbarContent justify="end">
-            <NavbarMenuToggle
-              aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
-              className="sm:hidden"
-            />
-          </NavbarContent>
+          {!isLoginPath && (
+            <NavbarContent justify="end">
+              <NavbarMenuToggle
+                aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+                className="sm:hidden"
+              />
+            </NavbarContent>
+          )}
         </div>
-        <div
-          className={`mt-2 hidden w-full border-t-3 border-blue-500 sm:block`}
-        >
-          <div className="container mx-auto flex justify-center gap-12 px-4 py-2">
-            {serviceItems.map(item => (
-              <NavLink key={item.name} href={item.href}>
-                {item.name}
-              </NavLink>
-            ))}
+        {!isLoginPath && (
+          <div
+            className={`mt-2 hidden w-full border-t-3 border-blue-500 sm:block`}
+          >
+            <div className="container mx-auto flex justify-center gap-12 px-4 py-2">
+              {serviceItems.map(item => (
+                <NavLink key={item.name} href={item.href}>
+                  {item.name}
+                </NavLink>
+              ))}
+            </div>
           </div>
-        </div>
-        <NavbarMenu>
-          {serviceItems.map(item => (
-            <NavbarMenuItem className="mb-4" key={`${item.name}`}>
-              <NavLink href={item.href} onClick={handleLinkClick}>
-                {item.name}
-              </NavLink>
-            </NavbarMenuItem>
-          ))}
-        </NavbarMenu>
+        )}
+        {!isLoginPath && (
+          <NavbarMenu>
+            {serviceItems.map(item => (
+              <NavbarMenuItem className="mb-4" key={`${item.name}`}>
+                <NavLink href={item.href} onClick={handleLinkClick}>
+                  {item.name}
+                </NavLink>
+              </NavbarMenuItem>
+            ))}
+          </NavbarMenu>
+        )}
       </Navbar>
     </>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,33 @@
+import { getServerSession } from '@/lib/auth'
 import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
 
-export default function Home() {
+export default async function Home() {
+  const session = await getServerSession()
+
+  const user = await prisma.user.findFirst({
+    where: {
+      id: session?.user.id ?? '',
+    },
+    select: {
+      userName: true,
+      industry: true,
+    },
+  })
+
   return (
     <>
       <div>ホーム</div>
+      {user?.userName && (
+        <div>
+          <div>ユーザー名: {user.userName}</div>
+        </div>
+      )}
+      {user?.industry && (
+        <div>
+          <div>業界: {user.industry}</div>
+        </div>
+      )}
       <Link href="/interview-feedback">インタビューページへ</Link>
     </>
   )


### PR DESCRIPTION
## ISSUE の URL

## 実装内容
ログイン画面と、ユーザー情報登録画面では、ヘッダーのタブを表示しない
<img width="809" alt="スクリーンショット 2024-06-05 10 43 44" src="https://github.com/mytty870/hackathon-repo/assets/84974943/59671598-d2ed-4287-8284-0ea723c25ab9">
<img width="675" alt="スクリーンショット 2024-06-05 10 43 32" src="https://github.com/mytty870/hackathon-repo/assets/84974943/c08542e2-e48f-4687-b7ad-fad97fee033d">

