### PR TITLE
面接評価ページのデザイン修正

### DIFF
--- a/src/app/_components/Layout/Header/Header.tsx
+++ b/src/app/_components/Layout/Header/Header.tsx
@@ -53,8 +53,8 @@ export const Header = ({ session }) => {
       >
         <div className="container mx-auto flex items-center justify-between px-4 py-2">
           <NavbarContent>
-            <h1 className="text-3xl font-semibold text-blue-600">
-              <Link href="/">就活AI</Link>
+            <h1 className="text-3xl font-semibold text-blue-600 tracking-tight">
+              <Link href="/">就活支援しまっせ！</Link>
             </h1>
           </NavbarContent>
           <NavbarContent justify="end">

--- a/src/app/interview/practice/_components/Questions/Evaluation/EvaluationDetails/EvaluationDetails.tsx
+++ b/src/app/interview/practice/_components/Questions/Evaluation/EvaluationDetails/EvaluationDetails.tsx
@@ -34,13 +34,21 @@ const EvaluationDetails: React.FC<EvaluationDetailsProps> = ({
     evaluationResult.response.evaluation5,
   ]
 
+  const labels = [
+    '口癖',
+    '一人称の統一',
+    '敬語の使い方',
+    '論理性',
+    '言葉の使い方',
+  ]
+
   return (
     <div>
       <h3>評価詳細 ({evaluationResult.filename})</h3>
       <ul className="m-0 list-none p-0">
         {evaluations.map((evaluation, index) => (
           <li key={index} className="my-2 border-b border-gray-300 py-2">
-            <strong>評価{index + 1}:</strong> スコア: {evaluation.score}, 理由:{' '}
+            <strong>{labels[index]}:</strong> スコア: {evaluation.score} , 理由:{' '}
             {evaluation.reason}
           </li>
         ))}

--- a/src/app/interview/practice/feedback/[id]/_components/Evaluation/Evaluation.tsx
+++ b/src/app/interview/practice/feedback/[id]/_components/Evaluation/Evaluation.tsx
@@ -264,10 +264,10 @@ export const Evaluation = ({ interviewSession }: EvaluationProps) => {
   console.log(totalScore)
 
   return (
-    <div>
-      <div className="flex flex-wrap justify-center">
-        <div className="w-full md:w-[70%] p-1">
-          <h2 className="text-center">総合スコア</h2>
+    <div className="bg-gray-100">
+      <div className="flex flex-wrap justify-center bg-gray-100">
+        <div className="w-full md:w-[70%] p-1 bg-white md:my-10">
+          <h2 className="text-center text-3xl mt-3">総合スコア</h2>
           <div className="flex flex-wrap items-start">
             <div className="order-1 w-full md:order-1 md:w-1/2 p-4">
               <h1 className="p-5 text-7xl text-center">{totalScore}点</h1>
@@ -300,24 +300,24 @@ export const Evaluation = ({ interviewSession }: EvaluationProps) => {
               </AccordionItem>
             ))}
           </Accordion>
+          <div className="flex flex-wrap justify-center mt-8 space-y-2 md:space-y-0 md:space-x-2 mb-4">
+            <Link href="/ranking" className="w-full md:w-auto px-9">
+              <Button className="w-full bg-blue-400 text-white hover:bg-blue-600 md:w-auto h-[50px]">
+                ランキングに移動する
+              </Button>
+            </Link>
+            <Link href="/mypage" className="w-full md:w-auto px-9">
+              <Button className="w-full bg-blue-400 text-white hover:bg-blue-600 md:w-auto h-[50px]">
+                過去の結果を確認する
+              </Button>
+            </Link>
+            <Link href="/interview" className="w-full md:w-auto px-9">
+              <Button className="w-full bg-blue-400 text-white hover:bg-blue-600 md:w-auto h-[50px]">
+                再度面接練習をする
+              </Button>
+            </Link>
+          </div>
         </div>
-      </div>
-      <div className="flex flex-wrap justify-center mt-5 space-y-2 md:space-y-0 md:space-x-2">
-        <Link href="/ranking" className="w-full md:w-auto px-9">
-          <Button className="w-full bg-blue-400 text-white hover:bg-blue-600 md:w-auto h-[50px]">
-            ランキングに移動する
-          </Button>
-        </Link>
-        <Link href="/mypage" className="w-full md:w-auto px-9">
-          <Button className="w-full bg-blue-400 text-white hover:bg-blue-600 md:w-auto h-[50px]">
-            過去の結果を確認する
-          </Button>
-        </Link>
-        <Link href="/interview" className="w-full md:w-auto px-9">
-          <Button className="w-full bg-blue-400 text-white hover:bg-blue-600 md:w-auto h-[50px]">
-            再度面接練習をする
-          </Button>
-        </Link>
       </div>
     </div>
   )

--- a/src/app/interview/practice/feedback/[id]/_components/Evaluation/EvaluationDetails/EvaluationDetails.tsx
+++ b/src/app/interview/practice/feedback/[id]/_components/Evaluation/EvaluationDetails/EvaluationDetails.tsx
@@ -1,14 +1,24 @@
 /* eslint-disable */
 
 export const EvaluationDetails = ({ evaluationResult }) => {
-  console.log('bb', evaluationResult)
+  const labels = [
+    '口癖',
+    '一人称の統一',
+    '敬語の使い方',
+    '論理性',
+    '言葉の使い方',
+  ]
+
   return (
     <div>
       <ul className="m-0 list-none p-0">
         {evaluationResult.map((evaluation, index) => (
           <li key={index} className="my-2 border-b border-gray-300 py-2">
-            <strong>評価{index + 1}:</strong> スコア: {evaluation.score}, 理由:{' '}
-            {evaluation.reason}
+            <div className="flex justify-between mb-2">
+              <p className="font-bold">{labels[index]}</p>
+              <p className="font-semibold">{evaluation.score}点</p>
+            </div>
+            <div>{evaluation.reason}</div>
           </li>
         ))}
       </ul>

--- a/src/app/interview/practice/feedback/[id]/_components/Evaluation/EvaluationRaderChart/EvaluationRaderChart.tsx
+++ b/src/app/interview/practice/feedback/[id]/_components/Evaluation/EvaluationRaderChart/EvaluationRaderChart.tsx
@@ -24,7 +24,13 @@ export const EvaluationRadarChart = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   evaluationResult,
 }) => {
-  const labels = ['評価1', '評価2', '評価3', '評価4', '評価5']
+  const labels = [
+    '口癖',
+    '一人称の統一',
+    '敬語の使い方',
+    '論理性',
+    '言葉の使い方',
+  ]
   const scores = [
     evaluationResult.evaluations[0].score,
     evaluationResult.evaluations[1].score,
@@ -54,6 +60,12 @@ export const EvaluationRadarChart = ({
         max: 20,
         ticks: {
           beginAtZero: true,
+        },
+        pointLabels: {
+          font: {
+            size: 12, // フォントサイズ
+            weight: 700, // フォントの太さを設定
+          },
         },
       },
     },

--- a/src/app/interview/practice/feedback/[id]/_components/Evaluation/TotalScoreRadarChart/TotalScoreRadarChart.tsx
+++ b/src/app/interview/practice/feedback/[id]/_components/Evaluation/TotalScoreRadarChart/TotalScoreRadarChart.tsx
@@ -21,7 +21,13 @@ ChartJS.register(
 )
 
 export const TotalEvaluationRadarChart = ({ evaluationResults }) => {
-  const labels = ['評価1', '評価2', '評価3', '評価4', '評価5']
+  const labels = [
+    '口癖',
+    '一人称の統一',
+    '敬語の使い方',
+    '論理性',
+    '言葉の使い方',
+  ]
 
   // 各評価のスコアを合計
 
@@ -46,6 +52,12 @@ export const TotalEvaluationRadarChart = ({ evaluationResults }) => {
         max: 100,
         ticks: {
           beginAtZero: true,
+        },
+        pointLabels: {
+          font: {
+            size: 12, // フォントサイズ
+            weight: 700, // フォントの太さを設定
+          },
         },
       },
     },

--- a/src/app/interview/practice/feedback/[id]/page.tsx
+++ b/src/app/interview/practice/feedback/[id]/page.tsx
@@ -25,7 +25,6 @@ export default async function Page({ params }: { params: { id: string } }) {
   return (
     <>
       <Evaluation interviewSession={interviewSession} />
-      <div>{interviewSession.id}</div>
     </>
   )
 }


### PR DESCRIPTION
## ISSUE の URL

## 実装内容
面接評価ページの細かいデザイン修正をした。
また、評価項目のラベルを適切なものに変更した。

<img width="1055" alt="スクリーンショット 2024-06-07 15 43 11" src="https://github.com/mytty870/hackathon-repo/assets/84974943/70c405bf-5d5f-46b5-b755-e216c59ef455">

<img width="829" alt="スクリーンショット 2024-06-07 15 43 32" src="https://github.com/mytty870/hackathon-repo/assets/84974943/4b3e53c6-5f7b-4834-afdb-fc228ce86b09">
